### PR TITLE
[PoC] Enable iPXE booting by adding 'network' to boot devices

### DIFF
--- a/builder/libvirt/domain.go
+++ b/builder/libvirt/domain.go
@@ -56,6 +56,7 @@ func newDomainDefinition(config *Config) libvirtxml.Domain {
 				Arch: "x86_64",
 				Type: "hvm",
 			},
+			BootDevices: []libvirtxml.DomainBootDevice{},
 		},
 		Features: &libvirtxml.DomainFeatureList{
 			PAE:  &libvirtxml.DomainFeature{},
@@ -63,6 +64,13 @@ func newDomainDefinition(config *Config) libvirtxml.Domain {
 			APIC: &libvirtxml.DomainFeatureAPIC{},
 		},
 	}
+
+	bootDevice1 := &libvirtxml.DomainBootDevice{}
+	bootDevice1.Dev = "hd"
+	domainDef.OS.BootDevices = append(domainDef.OS.BootDevices, *bootDevice1)
+	bootDevice2 := &libvirtxml.DomainBootDevice{}
+	bootDevice2.Dev = "network"
+	domainDef.OS.BootDevices = append(domainDef.OS.BootDevices, *bootDevice2)
 
 	for _, dg := range config.DomainGraphics {
 		domainDef.Devices.Graphics = append(domainDef.Devices.Graphics, *dg.DomainGraphic())


### PR DESCRIPTION
Not intended for merging (proof of concept); I am working on adding a config option
to set the boot devices, but `go generate ./...` has been running
for over 4.5 hours and is not yet complete (and I gather it is required
in order to allow the HCL2 to work).

In any event I 'manually' set the boot order to "hd" and then "network" in
the plugin domain generation, and with a "managed" network which has:

``` xml
  <ip address='192.168.125.1' netmask='255.255.255.0'>
    <dhcp>
      <range start='192.168.125.128' end='192.168.125.254'/>
      <bootp file='http://ipxe-boot.example.net/boot.ipxe'/>
    </dhcp>
  </ip>
```

I am able to use iPXE to launch an instance. This is useful for
initial provisioning of Alpine Linux which does not have cloud-init
images for Qemu/KVM or Libvirt atthe present time.

The iPXE script I use is similar to:

---

```
set base-url http://ipxe-boot.example.com

kernel ${base-url}/boot-3.16/vmlinuz-virt console=tty0 modules=loop,squashfs quiet nomodeset alpine_repo=https://dl-cdn.alpinelinux.org/alpine/v3.16/main modloop=https://ipxe-boot.example.com/boot-3.16/modloop-virt ssh_key="ssh-ed25519 AAAA..."
initrd ${base-url}/boot-3.16/initramfs-virt
boot
```

---

where ssh_key is an actual SSH public key in authorized_keys format.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>

I hope you find this an interesting and worthwhile idea. (And with luck I'll be able to add the config as a real PR eventually).