### PR TITLE
This adds a configuration option `boot_devices`

### DIFF
--- a/builder/libvirt/config.go
+++ b/builder/libvirt/config.go
@@ -123,7 +123,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if len(c.BootDevices) == 0 {
-		c.BootDevices[0] = "hd"
+		c.BootDevices = []string{"hd"}
 	}
 
 	for i, volumeDef := range c.Volumes {

--- a/builder/libvirt/config.go
+++ b/builder/libvirt/config.go
@@ -47,6 +47,10 @@ type Config struct {
 	// see [Volumes](#volumes)
 	ArtifactVolumeAlias string `mapstructure:"artifact_volume_alias" required:"false"`
 
+	// Device(s) from which to boot, defaults to hard drive (first volume)
+	// Available boot devices are: `hd`, `network`, `cdrom`
+	BootDevices []string `mapstructure:"boot_devices" required:"false"`
+
 	// See [Graphics and video, headless domains](#graphics-and-video-headless-domains).
 	DomainGraphics []DomainGraphic `mapstructure:"graphics" required:"false"`
 
@@ -116,6 +120,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.DomainName == "" {
 		c.DomainName = fmt.Sprintf("packer-%s", xid.New())
+	}
+
+	if len(c.BootDevices) == 0 {
+		c.BootDevices[0] = "hd"
 	}
 
 	for i, volumeDef := range c.Volumes {

--- a/builder/libvirt/config.go
+++ b/builder/libvirt/config.go
@@ -124,6 +124,19 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if len(c.BootDevices) == 0 {
 		c.BootDevices = []string{"hd"}
+	} else {
+		for _, bd := range c.BootDevices {
+			switch bd {
+			case "hd":
+				continue
+			case "network":
+				continue
+			case "cdrom":
+				continue
+			default:
+				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("unknown BootDevice: %s", bd))
+			}
+		}
 	}
 
 	for i, volumeDef := range c.Volumes {

--- a/builder/libvirt/domain.go
+++ b/builder/libvirt/domain.go
@@ -56,12 +56,19 @@ func newDomainDefinition(config *Config) libvirtxml.Domain {
 				Arch: "x86_64",
 				Type: "hvm",
 			},
+			BootDevices: []libvirtxml.DomainBootDevice{},
 		},
 		Features: &libvirtxml.DomainFeatureList{
 			PAE:  &libvirtxml.DomainFeature{},
 			ACPI: &libvirtxml.DomainFeature{},
 			APIC: &libvirtxml.DomainFeatureAPIC{},
 		},
+	}
+
+	for _, bd := range config.BootDevices {
+		bootDevice := &libvirtxml.DomainBootDevice{}
+		bootDevice.Dev = bd
+		domainDef.OS.BootDevices = append(domainDef.OS.BootDevices, *bootDevice)
 	}
 
 	for _, dg := range config.DomainGraphics {

--- a/builder/libvirt/domain.go
+++ b/builder/libvirt/domain.go
@@ -66,9 +66,8 @@ func newDomainDefinition(config *Config) libvirtxml.Domain {
 	}
 
 	for _, bd := range config.BootDevices {
-		bootDevice := &libvirtxml.DomainBootDevice{}
-		bootDevice.Dev = bd
-		domainDef.OS.BootDevices = append(domainDef.OS.BootDevices, *bootDevice)
+		bootDevice := libvirtxml.DomainBootDevice{Dev: bd}
+		domainDef.OS.BootDevices = append(domainDef.OS.BootDevices, bootDevice)
 	}
 
 	for _, dg := range config.DomainGraphics {

--- a/builder/libvirt/generate.hcl2spec.go
+++ b/builder/libvirt/generate.hcl2spec.go
@@ -33,6 +33,7 @@ type FlatConfig struct {
 	CommunicatorInterface *string                        `mapstructure:"communicator_interface" required:"false" cty:"communicator_interface" hcl:"communicator_interface"`
 	Volumes               []volume.FlatVolume            `mapstructure:"volume" required:"false" cty:"volume" hcl:"volume"`
 	ArtifactVolumeAlias   *string                        `mapstructure:"artifact_volume_alias" required:"false" cty:"artifact_volume_alias" hcl:"artifact_volume_alias"`
+	BootDevices           []string                       `mapstructure:"boot_devices" required:"false" cty:"boot_devices" hcl:"boot_devices"`
 	DomainGraphics        []FlatDomainGraphic            `mapstructure:"graphics" required:"false" cty:"graphics" hcl:"graphics"`
 	NetworkAddressSource  *string                        `mapstructure:"network_address_source" required:"false" cty:"network_address_source" hcl:"network_address_source"`
 	LibvirtURI            *string                        `mapstructure:"libvirt_uri" required:"true" cty:"libvirt_uri" hcl:"libvirt_uri"`
@@ -72,6 +73,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"communicator_interface":     &hcldec.AttrSpec{Name: "communicator_interface", Type: cty.String, Required: false},
 		"volume":                     &hcldec.BlockListSpec{TypeName: "volume", Nested: hcldec.ObjectSpec((*volume.FlatVolume)(nil).HCL2Spec())},
 		"artifact_volume_alias":      &hcldec.AttrSpec{Name: "artifact_volume_alias", Type: cty.String, Required: false},
+		"boot_devices":               &hcldec.AttrSpec{Name: "boot_devices", Type: cty.List(cty.String), Required: false},
 		"graphics":                   &hcldec.BlockListSpec{TypeName: "graphics", Nested: hcldec.ObjectSpec((*FlatDomainGraphic)(nil).HCL2Spec())},
 		"network_address_source":     &hcldec.AttrSpec{Name: "network_address_source", Type: cty.String, Required: false},
 		"libvirt_uri":                &hcldec.AttrSpec{Name: "libvirt_uri", Type: cty.String, Required: false},


### PR DESCRIPTION
to the domain config, which allows changing the boot device(s)
from the default of only from the first bootable hard drive ("hd").

I use this to set the boot device to "network" in
the plugin domain generation, and with a "managed" network which has:

``` xml
  <ip address='192.168.125.1' netmask='255.255.255.0'>
    <dhcp>
      <range start='192.168.125.128' end='192.168.125.254'/>
      <bootp file='http://ipxe-boot.example.net/boot.ipxe'/>
    </dhcp>
  </ip>
```

I am able to use iPXE to launch an instance. This is useful for
initial provisioning of Alpine Linux which does not have cloud-init
images for Qemu/KVM or Libvirt atthe present time.

The iPXE script I use is similar to:

---

```
set base-url http://ipxe-boot.example.com

kernel ${base-url}/boot-3.16/vmlinuz-virt console=tty0 modules=loop,squashfs quiet nomodeset alpine_repo=https://dl-cdn.alpinelinux.org/alpine/v3.16/main modloop=https://ipxe-boot.example.com/boot-3.16/modloop-virt ssh_key="ssh-ed25519 AAAA..."
initrd ${base-url}/boot-3.16/initramfs-virt
boot
```

---

where ssh_key is an actual SSH public key in authorized_keys format.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>