### PR TITLE
fix: Fix usage of port for TCP Dialer

### DIFF
--- a/libvirt-utils/dialers.go
+++ b/libvirt-utils/dialers.go
@@ -2,7 +2,6 @@ package libvirtutils
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/digitalocean/go-libvirt"
 	"github.com/digitalocean/go-libvirt/socket"
@@ -13,7 +12,7 @@ func NewDialerFromLibvirtUri(uri LibvirtUri) (dialer socket.Dialer, err error) {
 	case "ssh":
 		dialer, err = NewSshDialer(uri)
 	case "tls":
-		dialer, err = newTlsDialer(uri)
+		dialer, err = NewTlsDialer(uri)
 	case "tcp":
 		dialer, err = NewTcpDialer(uri)
 	case "unix", "":
@@ -40,10 +39,7 @@ func ConnectByUri(uri LibvirtUri) (*libvirt.Libvirt, error) {
 
 	connection := libvirt.NewWithDialer(dialer)
 
-	name := uri.Name()
-	log.Printf("[DEBUG] Sending '%s' to libvirtd as URI\n", name)
-	err = connection.ConnectToURI(libvirt.ConnectURI(name))
-
+	err = connection.ConnectToURI(libvirt.ConnectURI(uri.Name()))
 	if err != nil {
 		if uri.Driver == "test" {
 			err = nil

--- a/libvirt-utils/ssh_dialer.go
+++ b/libvirt-utils/ssh_dialer.go
@@ -3,7 +3,6 @@ package libvirtutils
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"strconv"
 
@@ -25,7 +24,6 @@ func (dialer *SshDialer) Dial() (net.Conn, error) {
 		return nil, fmt.Errorf("error connecting to libvirt via ssh: %s", err)
 	}
 	dialer.sshClient = client
-	log.Println("Libvirt SSH transport connected")
 
 	return client.Dial("unix", dialer.remoteUnixSocket)
 }

--- a/libvirt-utils/tcp_dialer.go
+++ b/libvirt-utils/tcp_dialer.go
@@ -7,17 +7,14 @@ import (
 )
 
 func NewTcpDialer(uri LibvirtUri) (*dialers.Remote, error) {
-	opts := []dialers.RemoteOption{}
-
 	if uri.Hostname == "" {
 		return nil, fmt.Errorf("hostname must be specified for tcp transport")
 	}
 
-	port := uri.Port
-	if port == "" {
-		port = "16509"
+	var opts []dialers.RemoteOption
+	if uri.Port != "" {
+		opts = append(opts, dialers.UsePort(uri.Port))
 	}
-	address := fmt.Sprintf("%s:%s", uri.Hostname, uri.Port)
 
-	return dialers.NewRemote(address, opts...), nil
+	return dialers.NewRemote(uri.Hostname, opts...), nil
 }

--- a/libvirt-utils/tls_dialer.go
+++ b/libvirt-utils/tls_dialer.go
@@ -11,8 +11,8 @@ import (
 )
 
 type TlsDialer struct {
-	address          string
-	tlsConfig        tls.Config
+	address   string
+	tlsConfig tls.Config
 }
 
 const (
@@ -25,10 +25,10 @@ func (dialer *TlsDialer) Dial() (net.Conn, error) {
 	return tls.Dial("tcp", dialer.address, &dialer.tlsConfig)
 }
 
-func newTlsDialer(uri LibvirtUri) (dialer *TlsDialer, err error) {
+func NewTlsDialer(uri LibvirtUri) (dialer *TlsDialer, err error) {
 	dialer = &TlsDialer{
-		address:          "",
-		tlsConfig:        tls.Config{},
+		address:   "",
+		tlsConfig: tls.Config{},
 	}
 	if err = tlsSetAddress(uri, dialer); err != nil {
 		return


### PR DESCRIPTION
Hello!

Changes done in this PR:
- Fixed connecting to libvirt by using TCP Dialer (connection wasn't possible, dedicated `dialers.UsePort` used right now).
- Small refactor of log messages (they were removed, thanks to that `github.com/thomasklein94/packer-plugin-libvirt/libvirtutils` can be used in different projects without uncontrolled logging to standard output).
- `NewTlsDialer` constructor is now exported (can be called externally).