### PR TITLE
add: expert flags to control uefi and machine settings

### DIFF
--- a/builder/libvirt/config.go
+++ b/builder/libvirt/config.go
@@ -69,6 +69,36 @@ type Config struct {
 	// stop before it destroys it. If not specified, Packer will wait for 5 minutes.
 	ShutdownTimeout time.Duration `mapstructure:"shutdown_timeout" required:"false"`
 
+	// [Expert] Domain type. It specifies the hypervisor used for running the domain.
+	// The allowed values are driver specific, but include "xen", "kvm", "hvf", "qemu" and "lxc".
+	// Default is kvm.
+	// If unsure, leave it empty.
+	DomainType string `mapstructure:"domain_type" required:"false"`
+	// [Expert] Domain architecture. Default is x86_64
+	Arch string `mapstructure:"arch" required:"false"`
+	// Libvirt Machine Type
+	// Value for domain XML's machine type. If unsure, leave it empty
+	Chipset string `mapstructure:"chipset" required:"false"`
+	// [Expert] Refers to a firmware blob, which is specified by absolute path, used to assist the domain creation process.
+	// If unsure, leave it empty.
+	LoaderPath string `mapstructure:"loader_path" required:"false"`
+	// [Expert] Accepts values rom and pflash. It tells the hypervisor where in the guest memory the loader(rom) should be mapped.
+	// If unsure, leave it empty.
+	LoaderType string `mapstructure:"loader_type" required:"false"`
+	// [Expert] Some firmwares may implement the Secure boot feature.
+	// This attribute can be used to tell the hypervisor that the firmware is capable of Secure Boot feature.
+	// It cannot be used to enable or disable the feature itself in the firmware.
+	// If unsure, leave it empty.
+	SecureBoot bool `mapstructure:"secure_boot" required:"false"`
+	// [Expert] Some UEFI firmwares may want to use a non-volatile memory to store some variables.
+	// In the host, this is represented as a file and the absolute path to the file is stored in this element.
+	// If unsure, leave it empty.`
+	NvramPath string `mapstructure:"nvram_path" required:"false"`
+	// [Expert] If the domain is an UEFI domain, libvirt copies a so called master NVRAM store file defined in qemu.conf.
+	// If needed, the template attribute can be used to per domain override map of master NVRAM stores from the config file.
+	// If unsure, leave it empty.
+	NvramTemplate string `mapstructure:"nvram_template" required:"false"`
+
 	ctx interpolate.Context
 }
 
@@ -185,6 +215,14 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if len(errs.Errors) > 0 {
 		return warnings, errs
+	}
+
+	if c.DomainType == "" {
+		c.DomainType = "kvm"
+	}
+
+	if c.Arch == "" {
+		c.Arch = "x86_64"
 	}
 
 	return warnings, nil

--- a/builder/libvirt/generate.hcl2spec.go
+++ b/builder/libvirt/generate.hcl2spec.go
@@ -39,6 +39,14 @@ type FlatConfig struct {
 	LibvirtURI            *string                        `mapstructure:"libvirt_uri" required:"true" cty:"libvirt_uri" hcl:"libvirt_uri"`
 	ShutdownMode          *string                        `mapstructure:"shutdown_mode" required:"false" cty:"shutdown_mode" hcl:"shutdown_mode"`
 	ShutdownTimeout       *string                        `mapstructure:"shutdown_timeout" required:"false" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
+	DomainType            *string                        `mapstructure:"domain_type" required:"false" cty:"domain_type" hcl:"domain_type"`
+	Arch                  *string                        `mapstructure:"arch" required:"false" cty:"arch" hcl:"arch"`
+	Chipset               *string                        `mapstructure:"chipset" required:"false" cty:"chipset" hcl:"chipset"`
+	LoaderPath            *string                        `mapstructure:"loader_path" required:"false" cty:"loader_path" hcl:"loader_path"`
+	LoaderType            *string                        `mapstructure:"loader_type" required:"false" cty:"loader_type" hcl:"loader_type"`
+	SecureBoot            *bool                          `mapstructure:"secure_boot" required:"false" cty:"secure_boot" hcl:"secure_boot"`
+	NvramPath             *string                        `mapstructure:"nvram_path" required:"false" cty:"nvram_path" hcl:"nvram_path"`
+	NvramTemplate         *string                        `mapstructure:"nvram_template" required:"false" cty:"nvram_template" hcl:"nvram_template"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -79,6 +87,14 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"libvirt_uri":                &hcldec.AttrSpec{Name: "libvirt_uri", Type: cty.String, Required: false},
 		"shutdown_mode":              &hcldec.AttrSpec{Name: "shutdown_mode", Type: cty.String, Required: false},
 		"shutdown_timeout":           &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
+		"domain_type":                &hcldec.AttrSpec{Name: "domain_type", Type: cty.String, Required: false},
+		"arch":                       &hcldec.AttrSpec{Name: "arch", Type: cty.String, Required: false},
+		"chipset":                    &hcldec.AttrSpec{Name: "chipset", Type: cty.String, Required: false},
+		"loader_path":                &hcldec.AttrSpec{Name: "loader_path", Type: cty.String, Required: false},
+		"loader_type":                &hcldec.AttrSpec{Name: "loader_type", Type: cty.String, Required: false},
+		"secure_boot":                &hcldec.AttrSpec{Name: "secure_boot", Type: cty.Bool, Required: false},
+		"nvram_path":                 &hcldec.AttrSpec{Name: "nvram_path", Type: cty.String, Required: false},
+		"nvram_template":             &hcldec.AttrSpec{Name: "nvram_template", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/docs-partials/builder/libvirt/Config-not-required.mdx
+++ b/docs-partials/builder/libvirt/Config-not-required.mdx
@@ -39,4 +39,33 @@
 - `shutdown_timeout` (duration string | ex: "1h5m2s") - After succesfull provisioning, Packer will wait this long for the virtual machine to gracefully
   stop before it destroys it. If not specified, Packer will wait for 5 minutes.
 
+- `domain_type` (string) - [Expert] Domain type. It specifies the hypervisor used for running the domain.
+  The allowed values are driver specific, but include "xen", "kvm", "hvf", "qemu" and "lxc".
+  Default is kvm.
+  If unsure, leave it empty.
+
+- `arch` (string) - [Expert] Domain architecture. Default is x86_64
+
+- `chipset` (string) - Libvirt Machine Type
+  Value for domain XML's machine type. If unsure, leave it empty
+
+- `loader_path` (string) - [Expert] Refers to a firmware blob, which is specified by absolute path, used to assist the domain creation process.
+  If unsure, leave it empty.
+
+- `loader_type` (string) - [Expert] Accepts values rom and pflash. It tells the hypervisor where in the guest memory the loader(rom) should be mapped.
+  If unsure, leave it empty.
+
+- `secure_boot` (bool) - [Expert] Some firmwares may implement the Secure boot feature.
+  This attribute can be used to tell the hypervisor that the firmware is capable of Secure Boot feature.
+  It cannot be used to enable or disable the feature itself in the firmware.
+  If unsure, leave it empty.
+
+- `nvram_path` (string) - [Expert] Some UEFI firmwares may want to use a non-volatile memory to store some variables.
+  In the host, this is represented as a file and the absolute path to the file is stored in this element.
+  If unsure, leave it empty.`
+
+- `nvram_template` (string) - [Expert] If the domain is an UEFI domain, libvirt copies a so called master NVRAM store file defined in qemu.conf.
+  If needed, the template attribute can be used to per domain override map of master NVRAM stores from the config file.
+  If unsure, leave it empty.
+
 <!-- End of code generated from the comments of the Config struct in builder/libvirt/config.go; -->


### PR DESCRIPTION
Adding extra flags for controlling the created Libvirt domain's settings. All these flags are optional, and leaving them empty should result in the same setup as it would be done by the previous release.

These settings allows users to use a different chipset or to boot into an UEFI environment.

Fixes: #7 