### PR TITLE
fix: Fix TLS hanging connection

### DIFF
--- a/libvirt-utils/tls_dialer.go
+++ b/libvirt-utils/tls_dialer.go
@@ -22,7 +22,15 @@ const (
 )
 
 func (dialer *TlsDialer) Dial() (net.Conn, error) {
-	return tls.Dial("tcp", dialer.address, &dialer.tlsConfig)
+	conn, err := tls.Dial("tcp", dialer.address, &dialer.tlsConfig)
+	// Workaround for hanging TLS connection described here: https://github.com/digitalocean/go-libvirt/issues/89
+	if err == nil {
+		_, err = conn.Read(make([]byte, 1))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return conn, err
 }
 
 func NewTlsDialer(uri LibvirtUri) (dialer *TlsDialer, err error) {


### PR DESCRIPTION
Fixing TLS hanging connection as described here: https://github.com/digitalocean/go-libvirt/issues/89

resolves: https://github.com/thomasklein94/packer-plugin-libvirt/issues/11