### PR TITLE
fix: missing SMM when secure_boot enabled

### DIFF
--- a/builder/libvirt/domain.go
+++ b/builder/libvirt/domain.go
@@ -97,6 +97,9 @@ func newDomainDefinition(config *Config) libvirtxml.Domain {
 		}
 		if config.SecureBoot {
 			domainDef.OS.Loader.Secure = "yes"
+			domainDef.Features.SMM = &libvirtxml.DomainFeatureSMM{
+				State: "yes",
+			}
 		}
 	}
 


### PR DESCRIPTION
Before, when ran with configuration option secure_boot set to true, building failed with the error message:
> DefineDomain.RPC: unsupported configuration: Secure boot requires SMM feature enabled

Fixes: #20