### PR TITLE
fix!: NVRAM path and NVRAM_template mixup

### DIFF
--- a/builder/libvirt/domain.go
+++ b/builder/libvirt/domain.go
@@ -105,8 +105,8 @@ func newDomainDefinition(config *Config) libvirtxml.Domain {
 
 	if config.NvramPath != "" || config.NvramTemplate != "" {
 		domainDef.OS.NVRam = &libvirtxml.DomainNVRam{
-			NVRam:    config.NvramTemplate,
-			Template: config.NvramPath,
+			NVRam:    config.NvramPath,
+			Template: config.NvramTemplate,
 		}
 	}
 


### PR DESCRIPTION
Previously NVRAM path and NVRAM template configurations were switched before added to the domain XML. If you have NVRAM set up for your packer source, make sure you check it again before the next build you run.

Fixes: #21