### PR TITLE
Add optional CPU mode argument

### DIFF
--- a/builder/libvirt/config.go
+++ b/builder/libvirt/config.go
@@ -35,6 +35,11 @@ type Config struct {
 	// The default is `1` CPU.
 	CpuCount int `mapstructure:"vcpu" required:"false"`
 
+	// Set CPU mode, you might want to set it to "host-passthrough".
+	// See [libvirt documentation](https://libvirt.org/formatdomain.html#cpu-model-and-topology) for more information.
+	// If not specified, let libvirt decide.
+	CpuMode string `mapstructure:"cpu_mode" required:"false"`
+
 	// Network interface attachments. See [Network](#network) for more.
 	NetworkInterfaces []network.NetworkInterface `mapstructure:"network_interface" required:"false"`
 	// The alias of the network interface used for the SSH/WinRM connections

--- a/builder/libvirt/domain.go
+++ b/builder/libvirt/domain.go
@@ -9,6 +9,9 @@ func newDomainDefinition(config *Config) libvirtxml.Domain {
 		Name:        config.DomainName,
 		Description: "Domain created by packer-plugin-libvirt",
 		Type:        config.DomainType,
+		CPU: &libvirtxml.DomainCPU{
+			Mode: config.CpuMode,
+		},
 		Memory: &libvirtxml.DomainMemory{
 			Value: uint(config.MemorySize),
 			Unit:  "MiB",

--- a/builder/libvirt/generate.hcl2spec.go
+++ b/builder/libvirt/generate.hcl2spec.go
@@ -29,6 +29,7 @@ type FlatConfig struct {
 	DomainName            *string                        `mapstructure:"domain_name" required:"false" cty:"domain_name" hcl:"domain_name"`
 	MemorySize            *int                           `mapstructure:"memory" required:"false" cty:"memory" hcl:"memory"`
 	CpuCount              *int                           `mapstructure:"vcpu" required:"false" cty:"vcpu" hcl:"vcpu"`
+	CpuMode               *string                        `mapstructure:"cpu_mode" required:"false" cty:"cpu_mode" hcl:"cpu_mode"`
 	NetworkInterfaces     []network.FlatNetworkInterface `mapstructure:"network_interface" required:"false" cty:"network_interface" hcl:"network_interface"`
 	CommunicatorInterface *string                        `mapstructure:"communicator_interface" required:"false" cty:"communicator_interface" hcl:"communicator_interface"`
 	Volumes               []volume.FlatVolume            `mapstructure:"volume" required:"false" cty:"volume" hcl:"volume"`
@@ -77,6 +78,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"domain_name":                &hcldec.AttrSpec{Name: "domain_name", Type: cty.String, Required: false},
 		"memory":                     &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"vcpu":                       &hcldec.AttrSpec{Name: "vcpu", Type: cty.Number, Required: false},
+		"cpu_mode":                   &hcldec.AttrSpec{Name: "cpu_mode", Type: cty.String, Required: false},
 		"network_interface":          &hcldec.BlockListSpec{TypeName: "network_interface", Nested: hcldec.ObjectSpec((*network.FlatNetworkInterface)(nil).HCL2Spec())},
 		"communicator_interface":     &hcldec.AttrSpec{Name: "communicator_interface", Type: cty.String, Required: false},
 		"volume":                     &hcldec.BlockListSpec{TypeName: "volume", Nested: hcldec.ObjectSpec((*volume.FlatVolume)(nil).HCL2Spec())},

--- a/docs-partials/builder/libvirt/Config-not-required.mdx
+++ b/docs-partials/builder/libvirt/Config-not-required.mdx
@@ -12,6 +12,10 @@
 - `vcpu` (int) - The number of cpus to use when building the VM.
   The default is `1` CPU.
 
+- `cpu_mode` (string) - Set CPU mode, you might want to set it to "host-passthrough".
+  See [libvirt documentation](https://libvirt.org/formatdomain.html#cpu-model-and-topology) for more information.
+  If not specified, let libvirt decide.
+
 - `network_interface` ([]network.NetworkInterface) - Network interface attachments. See [Network](#network) for more.
 
 - `communicator_interface` (string) - The alias of the network interface used for the SSH/WinRM connections


### PR DESCRIPTION
By default libvirt is picking a CPU incompatible with EL9, which requires x86_64-v2 minimum, relevant part of the XML
```xml
  <cpu mode="custom" match="exact" check="none">
    <model fallback="forbid">qemu64</model>
  </cpu>
```

After this PR, `host-model` generates
```xml
  <cpu mode="host-model" check="partial"/>
```