### PR TITLE
Add support for device type specification in volume, and some boyscouting

### DIFF
--- a/builder/libvirt/volume/generate.hcl2spec.go
+++ b/builder/libvirt/volume/generate.hcl2spec.go
@@ -124,6 +124,7 @@ type FlatVolume struct {
 	Bus       *string           `mapstructure:"bus" required:"false" cty:"bus" hcl:"bus"`
 	Alias     *string           `mapstructure:"alias" required:"false" cty:"alias" hcl:"alias"`
 	Format    *string           `mapstructure:"format" required:"false" cty:"format" hcl:"format"`
+	Device    *string           `mapstructure:"device" required:"false" cty:"device" hcl:"device"`
 }
 
 // FlatMapstructure returns a new FlatVolume.
@@ -148,6 +149,7 @@ func (*FlatVolume) HCL2Spec() map[string]hcldec.Spec {
 		"bus":        &hcldec.AttrSpec{Name: "bus", Type: cty.String, Required: false},
 		"alias":      &hcldec.AttrSpec{Name: "alias", Type: cty.String, Required: false},
 		"format":     &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
+		"device":     &hcldec.AttrSpec{Name: "device", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/libvirt/volume/volume.go
+++ b/builder/libvirt/volume/volume.go
@@ -61,6 +61,8 @@ type Volume struct {
 	// Specifies the volume format type, like `qcow`, `qcow2`, `vmdk`, `raw`. If omitted, the storage pool's default format
 	// will be used.
 	Format string `mapstructure:"format" required:"false"`
+	// Specifies the device type. If omitted, defaults to "disk".
+	Device string `mapstructure:"device" required:"false"`
 
 	allowUnspecifiedSize bool `undocumented:"true"`
 }
@@ -70,6 +72,10 @@ func (v *Volume) PrepareConfig(ctx *interpolate.Context, domainName string) (war
 	errs = []error{}
 
 	log.Println("Preparing volume config")
+
+	if v.Device == "" {
+		v.Device = "disk"
+	}
 
 	if v.Alias != "" {
 		v.Alias = fmt.Sprintf("ua-%s", v.Alias)
@@ -160,7 +166,7 @@ func (v *Volume) StorageDefinitionXml() (*libvirtxml.StorageVolume, error) {
 
 func (v *Volume) DomainDiskXml() *libvirtxml.DomainDisk {
 	domainDisk := &libvirtxml.DomainDisk{
-		Device: "disk",
+		Device: v.Device,
 		Source: &libvirtxml.DomainDiskSource{
 			Volume: &libvirtxml.DomainDiskSourceVolume{
 				Pool:   v.Pool,

--- a/docs-partials/builder/libvirt/volume/Volume-not-required.mdx
+++ b/docs-partials/builder/libvirt/volume/Volume-not-required.mdx
@@ -48,4 +48,6 @@
 - `format` (string) - Specifies the volume format type, like `qcow`, `qcow2`, `vmdk`, `raw`. If omitted, the storage pool's default format
   will be used.
 
+- `device` (string) - Specifies the device type. If omitted, defaults to "disk".
+
 <!-- End of code generated from the comments of the Volume struct in builder/libvirt/volume/volume.go; -->


### PR DESCRIPTION
This PR adds the ability to specify the device type of a volume, making it possible to mount volumes as cd-rom or floppy, which is required for unattended Windows installations making use of virtio-win.

I also included some small cleanups, namely:
* Upgrading libvirtxml to libvirt.org/go/libvirtxml, which is where development will happen going forward (the original repo has been archived)
* Making use of go run when running packer-sdc, which avoids needing a local install of the binary at a matching version (since go-run will use packer-sdc at the version defined in the go.mod)