### PR TITLE
network_interface type=direct, ssh agent added to libvirt_uri

### DIFF
--- a/builder/libvirt/network/direct.go
+++ b/builder/libvirt/network/direct.go
@@ -1,35 +1,35 @@
 package network
 
 import (
-        "fmt"
+	"fmt"
 
-        "github.com/hashicorp/packer-plugin-sdk/template/interpolate"
-        "libvirt.org/go/libvirtxml"
+	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+	"libvirt.org/go/libvirtxml"
 )
 
 type DirectNetworkInterface struct {
-        // For `type = "direct" interfaces, the name of the host direct device which the domain connects to
-        Dev string `mapstructure:"dev" required:"false"`
-        Mode string `mapstructure:"mode" required:"false"`
+	// For `type = "direct" interfaces, the name of the host direct device which the domain connects to
+	Dev string `mapstructure:"dev" required:"false"`
+	Mode string `mapstructure:"mode" required:"false"`
 }
 
 func (ni *DirectNetworkInterface) PrepareConfig(ctx *interpolate.Context) (warnings []string, errs []error) {
-        errs = []error{}
-        if ni.Dev == "" {
-                errs = append(errs, fmt.Errorf("network interfaces with type=direct must specify dev"))
-        }
-        if ni.Mode == "" {
-                errs = append(errs, fmt.Errorf("network interfaces with type=direct must specify mode"))
-        }
+	errs = []error{}
+	if ni.Dev == "" {
+		errs = append(errs, fmt.Errorf("network interfaces with type=direct must specify dev"))
+	}
+	if ni.Mode == "" {
+		errs = append(errs, fmt.Errorf("network interfaces with type=direct must specify mode"))
+	}
 
-        return
+	return
 }
 
 func (ni DirectNetworkInterface) UpdateDomainInterface(domainInterface *libvirtxml.DomainInterface) {
-        domainInterface.Source = &libvirtxml.DomainInterfaceSource{
-                Direct: &libvirtxml.DomainInterfaceSourceDirect{
-                        Dev: ni.Dev,
-                        Mode: ni.Mode,
-                },
-        }
+	domainInterface.Source = &libvirtxml.DomainInterfaceSource{
+		Direct: &libvirtxml.DomainInterfaceSourceDirect{
+			Dev: ni.Dev,
+			Mode: ni.Mode,
+		},
+	}
 }

--- a/builder/libvirt/network/direct.go
+++ b/builder/libvirt/network/direct.go
@@ -1,0 +1,35 @@
+package network
+
+import (
+        "fmt"
+
+        "github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+        "libvirt.org/go/libvirtxml"
+)
+
+type DirectNetworkInterface struct {
+        // For `type = "direct" interfaces, the name of the host direct device which the domain connects to
+        Dev string `mapstructure:"dev" required:"false"`
+        Mode string `mapstructure:"mode" required:"false"`
+}
+
+func (ni *DirectNetworkInterface) PrepareConfig(ctx *interpolate.Context) (warnings []string, errs []error) {
+        errs = []error{}
+        if ni.Dev == "" {
+                errs = append(errs, fmt.Errorf("network interfaces with type=direct must specify dev"))
+        }
+        if ni.Mode == "" {
+                errs = append(errs, fmt.Errorf("network interfaces with type=direct must specify mode"))
+        }
+
+        return
+}
+
+func (ni DirectNetworkInterface) UpdateDomainInterface(domainInterface *libvirtxml.DomainInterface) {
+        domainInterface.Source = &libvirtxml.DomainInterfaceSource{
+                Direct: &libvirtxml.DomainInterfaceSourceDirect{
+                        Dev: ni.Dev,
+                        Mode: ni.Mode,
+                },
+        }
+}

--- a/builder/libvirt/network/generate.hcl2spec.go
+++ b/builder/libvirt/network/generate.hcl2spec.go
@@ -10,12 +10,14 @@ import (
 // FlatNetworkInterface is an auto-generated flat version of NetworkInterface.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatNetworkInterface struct {
-	Type    *string `mapstructure:"type" required:"true" cty:"type" hcl:"type"`
-	Mac     *string `mapstructure:"mac" required:"false" cty:"mac" hcl:"mac"`
-	Alias   *string `mapstructure:"alias" required:"false" cty:"alias" hcl:"alias"`
-	Model   *string `mapstructure:"model" required:"false" cty:"model" hcl:"model"`
-	Bridge  *string `mapstructure:"bridge" required:"false" cty:"bridge" hcl:"bridge"`
-	Network *string `mapstructure:"network" required:"false" cty:"network" hcl:"network"`
+        Type    *string `mapstructure:"type" required:"true" cty:"type" hcl:"type"`
+        Mac     *string `mapstructure:"mac" required:"false" cty:"mac" hcl:"mac"`
+        Alias   *string `mapstructure:"alias" required:"false" cty:"alias" hcl:"alias"`
+        Model   *string `mapstructure:"model" required:"false" cty:"model" hcl:"model"`
+        Bridge  *string `mapstructure:"bridge" required:"false" cty:"bridge" hcl:"bridge"`
+        Network *string `mapstructure:"network" required:"false" cty:"network" hcl:"network"`
+        Mode  *string `mapstructure:"mode" required:"false" cty:"mode" hcl:"mode"`
+        Dev  *string `mapstructure:"dev" required:"false" cty:"dev" hcl:"dev"`
 }
 
 // FlatMapstructure returns a new FlatNetworkInterface.
@@ -29,13 +31,15 @@ func (*NetworkInterface) FlatMapstructure() interface{ HCL2Spec() map[string]hcl
 // This spec is used by HCL to read the fields of NetworkInterface.
 // The decoded values from this spec will then be applied to a FlatNetworkInterface.
 func (*FlatNetworkInterface) HCL2Spec() map[string]hcldec.Spec {
-	s := map[string]hcldec.Spec{
-		"type":    &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
-		"mac":     &hcldec.AttrSpec{Name: "mac", Type: cty.String, Required: false},
-		"alias":   &hcldec.AttrSpec{Name: "alias", Type: cty.String, Required: false},
-		"model":   &hcldec.AttrSpec{Name: "model", Type: cty.String, Required: false},
-		"bridge":  &hcldec.AttrSpec{Name: "bridge", Type: cty.String, Required: false},
-		"network": &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
-	}
-	return s
+        s := map[string]hcldec.Spec{
+                "type":    &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
+                "mac":     &hcldec.AttrSpec{Name: "mac", Type: cty.String, Required: false},
+                "alias":   &hcldec.AttrSpec{Name: "alias", Type: cty.String, Required: false},
+                "model":   &hcldec.AttrSpec{Name: "model", Type: cty.String, Required: false},
+                "bridge":  &hcldec.AttrSpec{Name: "bridge", Type: cty.String, Required: false},
+                "network": &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
+                "mode":  &hcldec.AttrSpec{Name: "mode", Type: cty.String, Required: false},
+                "dev":  &hcldec.AttrSpec{Name: "dev", Type: cty.String, Required: false},
+        }
+        return s
 }

--- a/builder/libvirt/network/generate.hcl2spec.go
+++ b/builder/libvirt/network/generate.hcl2spec.go
@@ -10,14 +10,14 @@ import (
 // FlatNetworkInterface is an auto-generated flat version of NetworkInterface.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatNetworkInterface struct {
-        Type    *string `mapstructure:"type" required:"true" cty:"type" hcl:"type"`
-        Mac     *string `mapstructure:"mac" required:"false" cty:"mac" hcl:"mac"`
-        Alias   *string `mapstructure:"alias" required:"false" cty:"alias" hcl:"alias"`
-        Model   *string `mapstructure:"model" required:"false" cty:"model" hcl:"model"`
-        Bridge  *string `mapstructure:"bridge" required:"false" cty:"bridge" hcl:"bridge"`
-        Network *string `mapstructure:"network" required:"false" cty:"network" hcl:"network"`
-        Mode  *string `mapstructure:"mode" required:"false" cty:"mode" hcl:"mode"`
-        Dev  *string `mapstructure:"dev" required:"false" cty:"dev" hcl:"dev"`
+	Type    *string `mapstructure:"type" required:"true" cty:"type" hcl:"type"`
+	Mac     *string `mapstructure:"mac" required:"false" cty:"mac" hcl:"mac"`
+	Alias   *string `mapstructure:"alias" required:"false" cty:"alias" hcl:"alias"`
+	Model   *string `mapstructure:"model" required:"false" cty:"model" hcl:"model"`
+	Bridge  *string `mapstructure:"bridge" required:"false" cty:"bridge" hcl:"bridge"`
+	Network *string `mapstructure:"network" required:"false" cty:"network" hcl:"network"`
+	Mode  *string `mapstructure:"mode" required:"false" cty:"mode" hcl:"mode"`
+	Dev  *string `mapstructure:"dev" required:"false" cty:"dev" hcl:"dev"`
 }
 
 // FlatMapstructure returns a new FlatNetworkInterface.
@@ -31,15 +31,15 @@ func (*NetworkInterface) FlatMapstructure() interface{ HCL2Spec() map[string]hcl
 // This spec is used by HCL to read the fields of NetworkInterface.
 // The decoded values from this spec will then be applied to a FlatNetworkInterface.
 func (*FlatNetworkInterface) HCL2Spec() map[string]hcldec.Spec {
-        s := map[string]hcldec.Spec{
-                "type":    &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
-                "mac":     &hcldec.AttrSpec{Name: "mac", Type: cty.String, Required: false},
-                "alias":   &hcldec.AttrSpec{Name: "alias", Type: cty.String, Required: false},
-                "model":   &hcldec.AttrSpec{Name: "model", Type: cty.String, Required: false},
-                "bridge":  &hcldec.AttrSpec{Name: "bridge", Type: cty.String, Required: false},
-                "network": &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
-                "mode":  &hcldec.AttrSpec{Name: "mode", Type: cty.String, Required: false},
-                "dev":  &hcldec.AttrSpec{Name: "dev", Type: cty.String, Required: false},
-        }
-        return s
+	s := map[string]hcldec.Spec{
+		"type":    &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
+		"mac":     &hcldec.AttrSpec{Name: "mac", Type: cty.String, Required: false},
+		"alias":   &hcldec.AttrSpec{Name: "alias", Type: cty.String, Required: false},
+		"model":   &hcldec.AttrSpec{Name: "model", Type: cty.String, Required: false},
+		"bridge":  &hcldec.AttrSpec{Name: "bridge", Type: cty.String, Required: false},
+		"network": &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
+		"mode":  &hcldec.AttrSpec{Name: "mode", Type: cty.String, Required: false},
+		"dev":  &hcldec.AttrSpec{Name: "dev", Type: cty.String, Required: false},
+	}
+	return s
 }

--- a/builder/libvirt/network/network.go
+++ b/builder/libvirt/network/network.go
@@ -3,87 +3,87 @@
 package network
 
 import (
-        "fmt"
+	"fmt"
 
-        "github.com/hashicorp/packer-plugin-sdk/template/interpolate"
-        "libvirt.org/go/libvirtxml"
+	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+	"libvirt.org/go/libvirtxml"
 )
 
 type NetworkInterface struct {
-        // [required] Type of attached network interface
-        Type string `mapstructure:"type" required:"true"`
-        // [optional] If needed, a MAC address can be specified for the network interface.
-        // If not specified, Libvirt will generate and assign a random MAC address
-        Mac string `mapstructure:"mac" required:"false"`
-        // [optional] To help users identifying devices they care about, every device can have an alias which must be unique within the domain.
-        // Additionally, the identifier must consist only of the following characters: `[a-zA-Z0-9_-]`.
-        Alias string `mapstructure:"alias" required:"false"`
-        // [optional] Defines how the interface should be modeled for the domain.
-        // Typical values for QEMU and KVM include: `ne2k_isa` `i82551` `i82557b` `i82559er` `ne2k_pci` `pcnet` `rtl8139` `e1000` `virtio`.
-        // If nothing is specified, `virtio` will be used as a default.
-        Model string `mapstructure:"model" required:"false"`
+	// [required] Type of attached network interface
+	Type string `mapstructure:"type" required:"true"`
+	// [optional] If needed, a MAC address can be specified for the network interface.
+	// If not specified, Libvirt will generate and assign a random MAC address
+	Mac string `mapstructure:"mac" required:"false"`
+	// [optional] To help users identifying devices they care about, every device can have an alias which must be unique within the domain.
+	// Additionally, the identifier must consist only of the following characters: `[a-zA-Z0-9_-]`.
+	Alias string `mapstructure:"alias" required:"false"`
+	// [optional] Defines how the interface should be modeled for the domain.
+	// Typical values for QEMU and KVM include: `ne2k_isa` `i82551` `i82557b` `i82559er` `ne2k_pci` `pcnet` `rtl8139` `e1000` `virtio`.
+	// If nothing is specified, `virtio` will be used as a default.
+	Model string `mapstructure:"model" required:"false"`
 
-        Bridge  BridgeNetworkInterface  `mapstructure:",squash"`
-        Direct  DirectNetworkInterface  `mapstructure:",squash"`
-        Managed ManagedNetworkInterface `mapstructure:",squash"`
+	Bridge  BridgeNetworkInterface  `mapstructure:",squash"`
+	Direct  DirectNetworkInterface  `mapstructure:",squash"`
+	Managed ManagedNetworkInterface `mapstructure:",squash"`
 }
 
 func (ni *NetworkInterface) PrepareConfig(ctx *interpolate.Context) (warnings []string, errs []error) {
-        warnings = []string{}
-        errs = []error{}
+	warnings = []string{}
+	errs = []error{}
 
-        if ni.Model == "" {
-                ni.Model = "virtio"
-        }
+	if ni.Model == "" {
+		ni.Model = "virtio"
+	}
 
-        if ni.Alias != "" {
-                ni.Alias = fmt.Sprintf("ua-%s", ni.Alias)
-        }
+	if ni.Alias != "" {
+		ni.Alias = fmt.Sprintf("ua-%s", ni.Alias)
+	}
 
-        var w []string
-        var e []error
-        switch ni.Type {
-        case "managed", "network":
-                w, e = ni.Managed.PrepareConfig(ctx)
-        case "direct":
-                w, e = ni.Direct.PrepareConfig(ctx)
-        case "bridge":
-                w, e = ni.Bridge.PrepareConfig(ctx)
-        default:
-                errs = append(errs, fmt.Errorf("unsupported network interface type '%s'", ni.Type))
-                return
-        }
-        warnings = append(warnings, w...)
-        errs = append(errs, e...)
+	var w []string
+	var e []error
+	switch ni.Type {
+	case "managed", "network":
+		w, e = ni.Managed.PrepareConfig(ctx)
+	case "direct":
+		w, e = ni.Direct.PrepareConfig(ctx)
+	case "bridge":
+		w, e = ni.Bridge.PrepareConfig(ctx)
+	default:
+		errs = append(errs, fmt.Errorf("unsupported network interface type '%s'", ni.Type))
+		return
+	}
+	warnings = append(warnings, w...)
+	errs = append(errs, e...)
 
-        return
+	return
 }
 
 func (ni NetworkInterface) DomainInterface() *libvirtxml.DomainInterface {
-        domainInterface := libvirtxml.DomainInterface{
-                Model: &libvirtxml.DomainInterfaceModel{
-                        Type: ni.Model,
-                },
-        }
-        if ni.Mac != "" {
-                domainInterface.MAC = &libvirtxml.DomainInterfaceMAC{
-                        Address: ni.Mac,
-                }
-        }
-        if ni.Alias != "" {
-                domainInterface.Alias = &libvirtxml.DomainAlias{
-                        Name: ni.Alias,
-                }
-        }
+	domainInterface := libvirtxml.DomainInterface{
+		Model: &libvirtxml.DomainInterfaceModel{
+			Type: ni.Model,
+		},
+	}
+	if ni.Mac != "" {
+		domainInterface.MAC = &libvirtxml.DomainInterfaceMAC{
+			Address: ni.Mac,
+		}
+	}
+	if ni.Alias != "" {
+		domainInterface.Alias = &libvirtxml.DomainAlias{
+			Name: ni.Alias,
+		}
+	}
 
-        switch ni.Type {
-        case "direct":
-                ni.Direct.UpdateDomainInterface(&domainInterface)
-        case "bridge":
-                ni.Bridge.UpdateDomainInterface(&domainInterface)
-        case "managed":
-                ni.Managed.UpdateDomainInterface(&domainInterface)
-        }
+	switch ni.Type {
+	case "direct":
+		ni.Direct.UpdateDomainInterface(&domainInterface)
+	case "bridge":
+		ni.Bridge.UpdateDomainInterface(&domainInterface)
+	case "managed":
+		ni.Managed.UpdateDomainInterface(&domainInterface)
+	}
 
-        return &domainInterface
+	return &domainInterface
 }

--- a/builder/libvirt/network/network.go
+++ b/builder/libvirt/network/network.go
@@ -3,82 +3,87 @@
 package network
 
 import (
-	"fmt"
+        "fmt"
 
-	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
-	"libvirt.org/go/libvirtxml"
+        "github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+        "libvirt.org/go/libvirtxml"
 )
 
 type NetworkInterface struct {
-	// [required] Type of attached network interface
-	Type string `mapstructure:"type" required:"true"`
-	// [optional] If needed, a MAC address can be specified for the network interface.
-	// If not specified, Libvirt will generate and assign a random MAC address
-	Mac string `mapstructure:"mac" required:"false"`
-	// [optional] To help users identifying devices they care about, every device can have an alias which must be unique within the domain.
-	// Additionally, the identifier must consist only of the following characters: `[a-zA-Z0-9_-]`.
-	Alias string `mapstructure:"alias" required:"false"`
-	// [optional] Defines how the interface should be modeled for the domain.
-	// Typical values for QEMU and KVM include: `ne2k_isa` `i82551` `i82557b` `i82559er` `ne2k_pci` `pcnet` `rtl8139` `e1000` `virtio`.
-	// If nothing is specified, `virtio` will be used as a default.
-	Model string `mapstructure:"model" required:"false"`
+        // [required] Type of attached network interface
+        Type string `mapstructure:"type" required:"true"`
+        // [optional] If needed, a MAC address can be specified for the network interface.
+        // If not specified, Libvirt will generate and assign a random MAC address
+        Mac string `mapstructure:"mac" required:"false"`
+        // [optional] To help users identifying devices they care about, every device can have an alias which must be unique within the domain.
+        // Additionally, the identifier must consist only of the following characters: `[a-zA-Z0-9_-]`.
+        Alias string `mapstructure:"alias" required:"false"`
+        // [optional] Defines how the interface should be modeled for the domain.
+        // Typical values for QEMU and KVM include: `ne2k_isa` `i82551` `i82557b` `i82559er` `ne2k_pci` `pcnet` `rtl8139` `e1000` `virtio`.
+        // If nothing is specified, `virtio` will be used as a default.
+        Model string `mapstructure:"model" required:"false"`
 
-	Bridge  BridgeNetworkInterface  `mapstructure:",squash"`
-	Managed ManagedNetworkInterface `mapstructure:",squash"`
+        Bridge  BridgeNetworkInterface  `mapstructure:",squash"`
+        Direct  DirectNetworkInterface  `mapstructure:",squash"`
+        Managed ManagedNetworkInterface `mapstructure:",squash"`
 }
 
 func (ni *NetworkInterface) PrepareConfig(ctx *interpolate.Context) (warnings []string, errs []error) {
-	warnings = []string{}
-	errs = []error{}
+        warnings = []string{}
+        errs = []error{}
 
-	if ni.Model == "" {
-		ni.Model = "virtio"
-	}
+        if ni.Model == "" {
+                ni.Model = "virtio"
+        }
 
-	if ni.Alias != "" {
-		ni.Alias = fmt.Sprintf("ua-%s", ni.Alias)
-	}
+        if ni.Alias != "" {
+                ni.Alias = fmt.Sprintf("ua-%s", ni.Alias)
+        }
 
-	var w []string
-	var e []error
-	switch ni.Type {
-	case "managed", "network":
-		w, e = ni.Managed.PrepareConfig(ctx)
-	case "bridge":
-		w, e = ni.Bridge.PrepareConfig(ctx)
-	default:
-		errs = append(errs, fmt.Errorf("unsupported network interface type '%s'", ni.Type))
-		return
-	}
-	warnings = append(warnings, w...)
-	errs = append(errs, e...)
+        var w []string
+        var e []error
+        switch ni.Type {
+        case "managed", "network":
+                w, e = ni.Managed.PrepareConfig(ctx)
+        case "direct":
+                w, e = ni.Direct.PrepareConfig(ctx)
+        case "bridge":
+                w, e = ni.Bridge.PrepareConfig(ctx)
+        default:
+                errs = append(errs, fmt.Errorf("unsupported network interface type '%s'", ni.Type))
+                return
+        }
+        warnings = append(warnings, w...)
+        errs = append(errs, e...)
 
-	return
+        return
 }
 
 func (ni NetworkInterface) DomainInterface() *libvirtxml.DomainInterface {
-	domainInterface := libvirtxml.DomainInterface{
-		Model: &libvirtxml.DomainInterfaceModel{
-			Type: ni.Model,
-		},
-	}
-	if ni.Mac != "" {
-		domainInterface.MAC = &libvirtxml.DomainInterfaceMAC{
-			Address: ni.Mac,
-		}
-	}
-	if ni.Alias != "" {
-		domainInterface.Alias = &libvirtxml.DomainAlias{
-			Name: ni.Alias,
-		}
-	}
+        domainInterface := libvirtxml.DomainInterface{
+                Model: &libvirtxml.DomainInterfaceModel{
+                        Type: ni.Model,
+                },
+        }
+        if ni.Mac != "" {
+                domainInterface.MAC = &libvirtxml.DomainInterfaceMAC{
+                        Address: ni.Mac,
+                }
+        }
+        if ni.Alias != "" {
+                domainInterface.Alias = &libvirtxml.DomainAlias{
+                        Name: ni.Alias,
+                }
+        }
 
-	switch ni.Type {
-	case "bridge":
-		ni.Bridge.UpdateDomainInterface(&domainInterface)
-	case "managed":
-		ni.Managed.UpdateDomainInterface(&domainInterface)
-	}
+        switch ni.Type {
+        case "direct":
+                ni.Direct.UpdateDomainInterface(&domainInterface)
+        case "bridge":
+                ni.Bridge.UpdateDomainInterface(&domainInterface)
+        case "managed":
+                ni.Managed.UpdateDomainInterface(&domainInterface)
+        }
 
-	return &domainInterface
+        return &domainInterface
 }

--- a/libvirt-utils/libvirt_uri.go
+++ b/libvirt-utils/libvirt_uri.go
@@ -52,7 +52,7 @@ func (uri *LibvirtUri) GetExtra(p LibvirtUriExtraParam) (string, bool) {
 }
 
 func (uri *LibvirtUri) Unmarshal(s string) error {
-	uriRegex := `^(?P<Driver>[a-z]+)(\+(?P<Transport>[a-z]+))?://(((?P<Username>[a-z_][-a-z0-9_]*\$?)@)?(?P<Hostname>[-_.a-z0-9]+)(:(?P<Port>[0-9]+)?)?)?(?P<Path>/[-_.a-z0-9]+)?(\?(?P<extra>.*))?$`
+	uriRegex := `^(?P<Driver>[a-z]+)(\+(?P<Transport>[a-z]+))?://(((?P<Username>[a-z_][-a-z0-9_\.]*\$?)@)?(?P<Hostname>[-_.a-z0-9]+)(:(?P<Port>[0-9]+)?)?)?(?P<Path>/[-_.a-z0-9]+)?(\?(?P<extra>.*))?$`
 	re := regexp.MustCompile(uriRegex)
 
 	matches := allMatchedRegexpGroups(re, s)

--- a/libvirt-utils/ssh_dialer.go
+++ b/libvirt-utils/ssh_dialer.go
@@ -90,47 +90,47 @@ func sshSetAddress(uri LibvirtUri, dialer *SshDialer) error {
 }
 
 func sshDialerSetPrivateKey(uri LibvirtUri, dialer *SshDialer) (err error) {
-        sock, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
-        if err != nil {
-                return err
-        }
+	sock, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
+	if err != nil {
+		return err
+	}
 
-        agent := agent.NewClient(sock)
+	agent := agent.NewClient(sock)
 
-        signers, err := agent.Signers()
-        if err != nil {
-                return err
-        }
+	signers, err := agent.Signers()
+	if err != nil {
+		return err
+	}
 
-        auths := []ssh.AuthMethod{ssh.PublicKeys(signers...)}
+	auths := []ssh.AuthMethod{ssh.PublicKeys(signers...)}
 
-        dialer.sshConfig.Auth = append(dialer.sshConfig.Auth, auths...)
+	dialer.sshConfig.Auth = append(dialer.sshConfig.Auth, auths...)
 
-        keyPath, ok := uri.GetExtra(LibvirtUriParam_Keyfile)
-        if ok {
-                expandedKeyPath, err := pathing.ExpandUser(keyPath)
+	keyPath, ok := uri.GetExtra(LibvirtUriParam_Keyfile)
+	if ok {
+		expandedKeyPath, err := pathing.ExpandUser(keyPath)
 
-                if err != nil {
-                        return err
-                }
+		if err != nil {
+			return err
+		}
 
-                key, err := ioutil.ReadFile(expandedKeyPath)
+		key, err := ioutil.ReadFile(expandedKeyPath)
 
-                if err != nil {
-                        return err
-                }
+		if err != nil {
+			return err
+		}
 
-                parsedKey, err := ssh.ParsePrivateKey(key)
+		parsedKey, err := ssh.ParsePrivateKey(key)
 
-                if err != nil {
-                        return err
-                }
+		if err != nil {
+			return err
+		}
 
-                dialer.sshConfig.Auth = append(dialer.sshConfig.Auth, ssh.PublicKeys(parsedKey))
+		dialer.sshConfig.Auth = append(dialer.sshConfig.Auth, ssh.PublicKeys(parsedKey))
 
-        }
+	}
 
-        return
+	return
 }
 
 func sshDialerSetVerification(uri LibvirtUri, dialer *SshDialer) error {


### PR DESCRIPTION
Hello. I was trying to use this in my environment, but found a few things that weren't implemented yet that I needed for my use case.

I don't know Go, but based on your code and documentation, I got this working in my environment.

In ssh_dialer, I added code that pulls auth info from the ssh agent by default. The keyfile parameter code is adjusted so that it only runs if the user passes a value. This section could be better - not sure the default behavior of libvirt, but I am usually able to rely on ssh agent to pass the keys without specification.

Next was adding a network_interface type of direct. This is macvtap in virt-manager config. It requires the host's dev to connect to and the mode (bridge).

I think it would be good to add knownhosts from ssh agent, too.

It would be cool to add these changes, but it may need more work. Wanted to commit and post before I forget, might be a while before I can delve into this more.